### PR TITLE
Removed navigation bar and slider lines on bottom, which are reflecting above slider images.

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,12 +27,12 @@
                 <h1 class="art-circle-heading">Welcome to PCCOE Art Circle</h1>
             </div>
 
-            <div id="carouselExampleIndicators" class="carousel slide" data-ride="carousel">
-                <ol class="carousel-indicators">
+            <div id="carouselExampleIndicators" class="carousel slide" data-ride="carousel" data-interval="2000">
+<!--                 <ol class="carousel-indicators">
                     <li data-target="#carouselExampleIndicators" data-slide-to="0" class="active"></li>
                     <li data-target="#carouselExampleIndicators" data-slide-to="1"></li>
                     <li data-target="#carouselExampleIndicators" data-slide-to="2"></li>
-                </ol>
+                </ol> -->
                 <div class="carousel-inner">
                     <div class="carousel-item active">
                         <img src="https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTEmrHp0eQNtPVArQZlEWr3ot9bzvPYZPIbM6PCetVyu1NTOju4SxW4EzAW8Kuryma-Uw&usqp=CAU"
@@ -47,14 +47,14 @@
                             class="d-block w-100" alt="...">
                     </div>
                 </div>
-                <a class="carousel-control-prev" href="#carouselExampleIndicators" role="button" data-slide="prev">
+<!--                 <a class="carousel-control-prev" href="#carouselExampleIndicators" role="button" data-slide="prev">
                     <span class="carousel-control-prev-icon" aria-hidden="true"></span>
                     <span class="sr-only">Previous</span>
                 </a>
                 <a class="carousel-control-next" href="#carouselExampleIndicators" role="button" data-slide="next">
                     <span class="carousel-control-next-icon" aria-hidden="true"></span>
                     <span class="sr-only">Next</span>
-                </a>
+                </a> -->
             </div>
 
             <div class="bottom-container">


### PR DESCRIPTION
Solved issue #3 

Hi this is Mugdha here. I have removed the navigation bar and slider lines on the bottom, which are reflected above slider images.

In 2 ways we can do it.
1. Either comment the carousel indicator code and respective icons code in index.html
2. Or in style.css just put display : none for these classes.

Thank,
Mugdha
